### PR TITLE
chore: update .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
       types: [file, python]
       args: [--max-line-length=100, --ignore=E203 E301 E302 E501 E402 E704 W503 W504]
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort Formatting


### PR DESCRIPTION
## Summary

This PR fixes pre-commit configuration, bump isort version to 5.12.0.